### PR TITLE
feat(db): add Prisma database package

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/photo

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 coverage
 .env
 .env.*
+!.env.example
 .DS_Store
 .idea
 .vscode

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "build": "turbo build",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
-    "format": "prettier -w ."
+    "format": "prettier -w .",
+    "db:generate": "pnpm -C packages/db prisma generate",
+    "db:migrate": "pnpm -C packages/db prisma migrate dev",
+    "db:seed": "pnpm -C packages/db tsx src/seed.ts"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "7.8.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@photo/db",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "prisma": "prisma",
+    "generate": "prisma generate",
+    "migrate": "prisma migrate dev",
+    "seed": "tsx src/seed.ts",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.19.1"
+  },
+  "devDependencies": {
+    "prisma": "^5.19.1",
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.2"
+  }
+}

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,0 +1,44 @@
+// url comes from DATABASE_URL in root .env
+// To enable pgvector later, we will add a SQL migration like:
+//   CREATE EXTENSION IF NOT EXISTS vector;
+//   ALTER TABLE "Face" ADD COLUMN embedding_vec vector(512);
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Image {
+  id         String   @id @default(uuid())
+  userId     String
+  storageKey String
+  url        String
+  status     String   @default("queued") // queued|processed|failed
+  createdAt  DateTime @default(now())
+  faces      Face[]
+}
+
+model Face {
+  id         String   @id @default(uuid())
+  imageId    String
+  userId     String
+  embedding  Bytes    // temporary; switch to pgvector later
+  bbox       Json
+  clusterId  String?
+  createdAt  DateTime @default(now())
+
+  image      Image    @relation(fields: [imageId], references: [id], onDelete: Cascade)
+  cluster    Cluster? @relation(fields: [clusterId], references: [id])
+}
+
+model Cluster {
+  id        String   @id @default(uuid())
+  userId    String
+  label     String?
+  createdAt DateTime @default(now())
+  faces     Face[]
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ['warn', 'error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,0 +1,30 @@
+import { prisma } from './client';
+
+async function main() {
+  const userId = '00000000-0000-0000-0000-000000000001';
+
+  console.log('Seeding base data…');
+
+  await prisma.image.upsert({
+    where: { id: '00000000-0000-0000-0000-000000000100' },
+    update: {},
+    create: {
+      id: '00000000-0000-0000-0000-000000000100',
+      userId,
+      storageKey: 'seed/example.jpg',
+      url: 'https://example.com/example.jpg',
+      status: 'queued',
+    },
+  });
+
+  console.log('Seed done');
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist" },
+  "include": ["src", "prisma"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "apps/*"
+  - "packages/*"


### PR DESCRIPTION
## Summary
- add a reusable @photo/db workspace package with Prisma client, schema, and seed helper
- expose shared Prisma client singleton for other apps and lightweight seed data
- wire up root scripts and workspace config so database tasks run via pnpm

## Testing
- pnpm install *(fails: registry access blocked in environment)*
- pnpm -C packages/db typecheck *(fails: registry access blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de97dbe234833291d69a03c7b52cd2