### PR TITLE
feat: add S3 presigned upload API and drag-and-drop uploader

### DIFF
--- a/apps/web/app/api/uploads/route.ts
+++ b/apps/web/app/api/uploads/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { v4 as uuidv4 } from 'uuid';
+
+import { getPresignedGetUrl, getPresignedPutUrl } from '../../../lib/s3';
+
+const bodySchema = z.object({
+  count: z.number().int().min(1).max(200),
+  contentTypes: z.array(z.string()),
+});
+
+const extensionMap: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/heic': 'heic',
+  'image/heif': 'heif',
+};
+
+function deriveExtension(contentType: string): string | undefined {
+  const mapped = extensionMap[contentType];
+  if (mapped) {
+    return mapped;
+  }
+  const parts = contentType.split('/');
+  if (parts.length === 2 && parts[1]) {
+    const sanitized = parts[1].toLowerCase();
+    if (/^[a-z0-9.+-]+$/.test(sanitized)) {
+      return sanitized;
+    }
+  }
+  return undefined;
+}
+
+function buildKey(contentType: string, now: Date): string {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(now.getUTCDate()).padStart(2, '0');
+  const base = `uploads/${year}/${month}/${day}`;
+  const ext = deriveExtension(contentType);
+  const suffix = ext ? `.${ext}` : '';
+  return `${base}/${uuidv4()}${suffix}`;
+}
+
+// @auth: wire NextAuth later but do not block
+export async function POST(request: NextRequest) {
+  let parsed;
+  try {
+    const json = await request.json();
+    parsed = bodySchema.parse(json);
+  } catch (error) {
+    return NextResponse.json(
+      { code: 'bad_request', message: 'Invalid request body.' },
+      { status: 400 }
+    );
+  }
+
+  const { count, contentTypes } = parsed;
+
+  if (contentTypes.length !== count) {
+    return NextResponse.json(
+      { code: 'bad_request', message: 'contentTypes length must match count.' },
+      { status: 400 }
+    );
+  }
+
+  if (contentTypes.some((type) => !type || !type.startsWith('image/'))) {
+    return NextResponse.json(
+      { code: 'bad_request', message: 'Only image content types are allowed.' },
+      { status: 400 }
+    );
+  }
+
+  console.log(`[api/uploads] ${request.method} count=${count}`);
+
+  const now = new Date();
+
+  try {
+    const items = await Promise.all(
+      contentTypes.map(async (contentType) => {
+        const key = buildKey(contentType, now);
+        const [putUrl, getUrl] = await Promise.all([
+          getPresignedPutUrl(key, contentType),
+          getPresignedGetUrl(key),
+        ]);
+
+        return { key, putUrl, getUrl, contentType };
+      })
+    );
+
+    return NextResponse.json(items);
+  } catch (error) {
+    console.error('[api/uploads] failed to create presigned URLs', error);
+    return NextResponse.json(
+      { code: 'internal_error', message: 'Failed to generate presigned URLs.' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/upload/page.tsx
+++ b/apps/web/app/upload/page.tsx
@@ -1,0 +1,14 @@
+import Uploader from '../../components/Uploader';
+
+export default function UploadPage() {
+  return (
+    <main style={{ maxWidth: '800px', margin: '0 auto', padding: '2rem 1rem' }}>
+      <h1 style={{ fontSize: '1.75rem', fontWeight: 600, marginBottom: '1rem' }}>Upload images</h1>
+      <p style={{ marginBottom: '2rem', color: '#555' }}>
+        Use the uploader below to send images directly to S3 via presigned URLs. Start Localstack
+        and run <code>pnpm infra:up</code> before testing.
+      </p>
+      <Uploader />
+    </main>
+  );
+}

--- a/apps/web/components/Uploader.tsx
+++ b/apps/web/components/Uploader.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { FileRejection, useDropzone } from 'react-dropzone';
+
+type UploadStatus = 'pending' | 'uploading' | 'done' | 'error';
+
+type UploadItem = {
+  id: string;
+  file: File;
+  progress: number;
+  status: UploadStatus;
+  error?: string;
+  getUrl?: string;
+};
+
+type PresignedUpload = {
+  key: string;
+  putUrl: string;
+  getUrl: string;
+  contentType: string;
+};
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes)) {
+    return `${bytes} B`;
+  }
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const decimals = value >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${value.toFixed(decimals)} ${units[unitIndex]}`;
+}
+
+export default function Uploader() {
+  const [uploads, setUploads] = useState<UploadItem[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const updateUpload = useCallback((id: string, patch: Partial<UploadItem>) => {
+    setUploads((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, ...patch } : item))
+    );
+  }, []);
+
+  const uploadWithXhr = useCallback(
+    (id: string, file: File, presigned: PresignedUpload) =>
+      new Promise<void>((resolve, reject) => {
+        updateUpload(id, {
+          status: 'uploading',
+          progress: 0,
+          error: undefined,
+          getUrl: undefined,
+        });
+
+        const xhr = new XMLHttpRequest();
+        xhr.open('PUT', presigned.putUrl, true);
+        xhr.setRequestHeader('Content-Type', presigned.contentType);
+
+        xhr.upload.onprogress = (event) => {
+          if (event.lengthComputable && event.total > 0) {
+            const percent = Math.round((event.loaded / event.total) * 100);
+            updateUpload(id, { progress: percent });
+          }
+        };
+
+        xhr.onerror = () => {
+          const message = 'Network error while uploading file.';
+          updateUpload(id, { status: 'error', error: message });
+          reject(new Error(message));
+        };
+
+        xhr.onload = () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            updateUpload(id, { progress: 100, status: 'done', getUrl: presigned.getUrl });
+            resolve();
+          } else {
+            const message = `Upload failed with status ${xhr.status}.`;
+            updateUpload(id, { status: 'error', error: message });
+            reject(new Error(message));
+          }
+        };
+
+        xhr.send(file);
+      }),
+    [updateUpload]
+  );
+
+  const handleDropRejected = useCallback((fileRejections: FileRejection[]) => {
+    const description = fileRejections
+      .map((rejection) =>
+        rejection.errors.map((err) => `${rejection.file.name}: ${err.message}`).join(', ')
+      )
+      .join(', ');
+    window.alert(description || 'Some files were rejected. Please upload images only.');
+  }, []);
+
+  const onDrop = useCallback(
+    async (acceptedFiles: File[]) => {
+      if (acceptedFiles.length === 0) {
+        return;
+      }
+
+      const initialItems: UploadItem[] = acceptedFiles.map((file, index) => ({
+        id: `${Date.now()}-${index}-${file.name}`,
+        file,
+        progress: 0,
+        status: 'pending',
+      }));
+
+      setUploads(initialItems);
+      setIsUploading(true);
+
+      try {
+        const response = await fetch('/api/uploads', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            count: acceptedFiles.length,
+            contentTypes: acceptedFiles.map((file) => file.type),
+          }),
+        });
+
+        const payload = await response.json().catch(() => null);
+
+        if (!response.ok) {
+          const message = (payload && payload.message) || 'Failed to request upload URLs.';
+          throw new Error(message);
+        }
+
+        if (!Array.isArray(payload) || payload.length !== acceptedFiles.length) {
+          throw new Error('Unexpected response from upload endpoint.');
+        }
+
+        const uploadsResult = await Promise.allSettled(
+          payload.map((item, index) => {
+            if (
+              typeof item !== 'object' ||
+              item === null ||
+              typeof item.putUrl !== 'string' ||
+              typeof item.getUrl !== 'string' ||
+              typeof item.key !== 'string' ||
+              typeof item.contentType !== 'string'
+            ) {
+              return Promise.reject<void>(new Error('Malformed upload response.'));
+            }
+
+            const presigned: PresignedUpload = {
+              key: item.key,
+              putUrl: item.putUrl,
+              getUrl: item.getUrl,
+              contentType: item.contentType,
+            };
+
+            return uploadWithXhr(initialItems[index].id, acceptedFiles[index], presigned);
+          })
+        );
+
+        const firstError = uploadsResult.find(
+          (result): result is PromiseRejectedResult => result.status === 'rejected'
+        );
+
+        if (firstError) {
+          const message =
+            firstError.reason instanceof Error
+              ? firstError.reason.message
+              : 'One or more uploads failed.';
+          throw new Error(message);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Upload failed.';
+        setUploads((prev) =>
+          prev.map((item) =>
+            item.status === 'done' ? item : { ...item, status: 'error', error: message }
+          )
+        );
+        window.alert(message);
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [uploadWithXhr]
+  );
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    onDropRejected: handleDropRejected,
+    accept: { 'image/*': [] },
+    multiple: true,
+    disabled: isUploading,
+  });
+
+  return (
+    <section>
+      <div
+        {...getRootProps({
+          className: 'uploader-dropzone',
+          style: {
+            border: '2px dashed #888',
+            borderRadius: '8px',
+            padding: '2rem',
+            textAlign: 'center',
+            backgroundColor: isDragActive ? '#f0f6ff' : '#fafafa',
+            color: '#333',
+            cursor: isUploading ? 'not-allowed' : 'pointer',
+            outline: 'none',
+          },
+          tabIndex: 0,
+        })}
+        aria-busy={isUploading}
+      >
+        <input {...getInputProps()} />
+        <p style={{ fontSize: '1rem', margin: 0 }}>
+          {isDragActive ? 'Drop the images here…' : 'Drag and drop images here, or click to browse.'}
+        </p>
+        <p style={{ marginTop: '0.5rem', color: '#666' }}>
+          {isUploading
+            ? `Uploading ${uploads.length} file${uploads.length === 1 ? '' : 's'}…`
+            : 'Only image files are supported.'}
+        </p>
+      </div>
+
+      {uploads.length > 0 && (
+        <ul style={{ listStyle: 'none', marginTop: '1.5rem', padding: 0 }}>
+          {uploads.map((item) => (
+            <li
+              key={item.id}
+              style={{
+                border: '1px solid #e0e0e0',
+                borderRadius: '6px',
+                padding: '1rem',
+                marginBottom: '1rem',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '0.5rem',
+              }}
+            >
+              <div style={{ display: 'flex', justifyContent: 'space-between', gap: '1rem' }}>
+                <div>
+                  <strong style={{ display: 'block' }}>{item.file.name}</strong>
+                  <span style={{ color: '#666' }}>{formatBytes(item.file.size)}</span>
+                </div>
+                {item.getUrl && item.status === 'done' && (
+                  <a
+                    href={item.getUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ color: '#1d4ed8' }}
+                  >
+                    Preview
+                  </a>
+                )}
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}>
+                <progress value={item.progress} max={100} style={{ width: '100%' }} />
+                <span aria-live="polite">
+                  {item.status === 'uploading'
+                    ? `Uploading… ${item.progress}%`
+                    : item.status === 'done'
+                    ? 'Upload complete'
+                    : item.status === 'error'
+                    ? `Error: ${item.error ?? 'Upload failed.'}`
+                    : 'Waiting to upload'}
+                </span>
+              </div>
+              {item.error && item.status === 'error' && (
+                <span role="alert" style={{ color: '#b91c1c' }}>
+                  {item.error}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -1,0 +1,13 @@
+export const env = {
+  S3_ENDPOINT: process.env.S3_ENDPOINT ?? 'http://localhost:4566',
+  S3_REGION: process.env.S3_REGION ?? 'us-east-1',
+  S3_BUCKET: must('S3_BUCKET'),
+  S3_ACCESS_KEY_ID: must('S3_ACCESS_KEY_ID'),
+  S3_SECRET_ACCESS_KEY: must('S3_SECRET_ACCESS_KEY'),
+};
+
+function must(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing env ${name}`);
+  return v;
+}

--- a/apps/web/lib/s3.ts
+++ b/apps/web/lib/s3.ts
@@ -1,0 +1,34 @@
+import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+
+import { env } from './env';
+
+export const s3 = new S3Client({
+  region: env.S3_REGION,
+  endpoint: env.S3_ENDPOINT,
+  forcePathStyle: true,
+  credentials: {
+    accessKeyId: env.S3_ACCESS_KEY_ID,
+    secretAccessKey: env.S3_SECRET_ACCESS_KEY,
+  },
+});
+
+const EXPIRES = 60 * 10; // 10 minutes
+
+export async function getPresignedPutUrl(key: string, contentType: string) {
+  const cmd = new PutObjectCommand({
+    Bucket: env.S3_BUCKET,
+    Key: key,
+    ContentType: contentType,
+    ACL: 'private',
+  });
+  return getSignedUrl(s3, cmd, { expiresIn: EXPIRES });
+}
+
+export async function getPresignedGetUrl(key: string) {
+  const cmd = new GetObjectCommand({
+    Bucket: env.S3_BUCKET,
+    Key: key,
+  });
+  return getSignedUrl(s3, cmd, { expiresIn: EXPIRES });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,9 +9,14 @@
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.556.0",
+    "@aws-sdk/s3-request-presigner": "^3.556.0",
     "next": "14.2.3",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-dropzone": "^14.2.3",
+    "uuid": "^9.0.1",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "20.12.7",


### PR DESCRIPTION
## Summary
- add S3 environment helpers and AWS SDK client for presigned URLs
- implement /api/uploads route that validates image uploads and returns presigned PUT/GET URLs
- build drag-and-drop uploader UI with progress tracking and new /upload page

## Testing
- pnpm install *(fails: network restrictions prevented downloading pnpm package manager)*

------
https://chatgpt.com/codex/tasks/task_e_68de9b306cf08332ad58965b9bcebd27