### PR TITLE
feat: ingest job flow with Redis-backed polling

### DIFF
--- a/apps/web/app/api/ingest/route.ts
+++ b/apps/web/app/api/ingest/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { redis } from '@/app/../lib/redis';
+import { prisma } from '@photo/db/src/client';
+import { customAlphabet } from 'nanoid';
+
+const nanoid = customAlphabet('0123456789abcdefghijklmnopqrstuvwxyz', 18);
+
+const BodySchema = z.object({
+  photos: z
+    .array(
+      z.object({
+        key: z.string().min(3),
+        contentType: z.string().regex(/^image\//),
+      })
+    )
+    .min(1)
+    .max(500),
+});
+
+export async function POST(req: Request) {
+  try {
+    const json = await req.json();
+    const parsed = BodySchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { code: 'BAD_REQUEST', message: 'Invalid body', details: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const { photos } = parsed.data;
+
+    // Persist images as queued (idempotent per key+user later; for now by key only)
+    // Note: userId is placeholder for now; wire NextAuth later.
+    const userId = '00000000-0000-0000-0000-000000000001';
+
+    // Basic URL composer for later preview (signed GET better; for now keep storageKey+url same)
+    const s3Endpoint = process.env.S3_ENDPOINT ?? 'http://localhost:4566';
+    const bucket = process.env.S3_BUCKET ?? 'photos';
+
+    // Upsert images
+    for (const p of photos) {
+      const storageKey = p.key;
+      const url = `${s3Endpoint}/${bucket}/${encodeURIComponent(storageKey)}`;
+      await prisma.image.upsert({
+        where: {
+          // we don't have unique by storageKey; emulate with composite unique if needed.
+          // For now, create a deterministic id from key hash would be nicer; keep simple: findFirst then create.
+          id: crypto.randomUUID(),
+        },
+        update: {},
+        create: {
+          userId,
+          storageKey,
+          url,
+          status: 'queued',
+        },
+      });
+    }
+
+    // Create a job in Redis
+    const jobId = nanoid();
+    const startedAt = Date.now();
+    const total = photos.length;
+
+    const jobKey = `job:${jobId}`;
+    await redis.hmset(jobKey, {
+      id: jobId,
+      startedAt: String(startedAt),
+      total: String(total),
+      status: 'running',
+      // mark not finalized
+      finalized: '0',
+    });
+    await redis.expire(jobKey, 60 * 10); // 10 minutes TTL
+
+    return NextResponse.json({ jobId }, { status: 202 });
+  } catch (err) {
+    console.error('[ingest] error', err);
+    return NextResponse.json({ code: 'INTERNAL', message: 'Failed to start ingest' }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/jobs/[id]/status/route.ts
+++ b/apps/web/app/api/jobs/[id]/status/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { redis } from '@/app/../../lib/redis';
+import { prisma } from '@photo/db/src/client';
+
+type JobState = {
+  id: string;
+  startedAt: number;
+  total: number;
+  status: 'queued' | 'running' | 'completed' | 'failed';
+  finalized: boolean;
+};
+
+const DURATION_MS = 8000; // 8s to 100%
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const jobId = params.id;
+  const jobKey = `job:${jobId}`;
+  const raw = await redis.hgetall(jobKey);
+
+  if (!raw || Object.keys(raw).length === 0) {
+    return NextResponse.json({ code: 'NOT_FOUND', message: 'Job not found' }, { status: 404 });
+  }
+
+  const job: JobState = {
+    id: raw.id,
+    startedAt: Number(raw.startedAt),
+    total: Number(raw.total),
+    status: (raw.status as JobState['status']) || 'running',
+    finalized: raw.finalized === '1',
+  };
+
+  const now = Date.now();
+  const elapsed = Math.max(0, now - job.startedAt);
+  const progress = Math.min(100, Math.floor((elapsed / DURATION_MS) * 100));
+  let status: JobState['status'] = progress >= 100 ? 'completed' : 'running';
+
+  // Once completed first time, mark finalized and persist images as processed
+  if (status === 'completed' && !job.finalized) {
+    // Update finalized flag
+    await redis.hset(jobKey, { finalized: '1', status: 'completed' });
+
+    // Mark all 'queued' images as processed for demo purposes.
+    // In a real pipeline, we'd scope to this job's images (store keys on job).
+    await prisma.image.updateMany({
+      where: { status: 'queued' },
+      data: { status: 'processed' },
+    });
+  }
+
+  return NextResponse.json({ status, progress });
+}

--- a/apps/web/app/upload/page.tsx
+++ b/apps/web/app/upload/page.tsx
@@ -1,14 +1,15 @@
-import Uploader from '../../components/Uploader';
+import Uploader from '@/components/Uploader';
 
 export default function UploadPage() {
   return (
-    <main style={{ maxWidth: '800px', margin: '0 auto', padding: '2rem 1rem' }}>
-      <h1 style={{ fontSize: '1.75rem', fontWeight: 600, marginBottom: '1rem' }}>Upload images</h1>
-      <p style={{ marginBottom: '2rem', color: '#555' }}>
-        Use the uploader below to send images directly to S3 via presigned URLs. Start Localstack
-        and run <code>pnpm infra:up</code> before testing.
+    <main className="mx-auto max-w-3xl p-8">
+      <h1 className="text-2xl font-semibold">Upload & Ingest</h1>
+      <p style={{ color: '#666', marginTop: 8 }}>
+        Hãy chạy <code>pnpm infra:up</code> trước. Sau khi upload, hệ thống sẽ giả lập xử lý (~8s).
       </p>
-      <Uploader />
+      <div style={{ marginTop: 16 }}>
+        <Uploader />
+      </div>
     </main>
   );
 }

--- a/apps/web/lib/redis.ts
+++ b/apps/web/lib/redis.ts
@@ -1,0 +1,19 @@
+import Redis from 'ioredis';
+
+const url = process.env.REDIS_URL || 'redis://localhost:6379';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __redis__: Redis | undefined;
+}
+
+export const redis =
+  global.__redis__ ??
+  new Redis(url, {
+    maxRetriesPerRequest: 3,
+    enableAutoPipelining: true,
+  });
+
+if (process.env.NODE_ENV !== 'production') {
+  global.__redis__ = redis;
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.556.0",
     "@aws-sdk/s3-request-presigner": "^3.556.0",
+    "ioredis": "^5.4.1",
     "next": "14.2.3",
+    "nanoid": "^5.0.7",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-dropzone": "^14.2.3",


### PR DESCRIPTION
## Summary
- add Redis client helper and wire new ingest API to queue uploaded photos and start jobs
- expose job status endpoint that simulates 8s processing and marks queued images as processed
- extend uploader UI to start ingest, poll job status, and show progress after uploads

## Testing
- `pnpm install` *(fails: network proxy blocked npm registry download)*

------
https://chatgpt.com/codex/tasks/task_e_68de9ef8fce883328408c1e31e1a8028