### PR TITLE
feat(gallery): add /api/photos with cursor pagination and infinite-scroll gallery (PR#6)

### DIFF
--- a/apps/web/app/api/photos/route.ts
+++ b/apps/web/app/api/photos/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { prisma } from '@photo/db/src/client';
+
+const QuerySchema = z.object({
+  status: z
+    .enum(['processed', 'queued', 'failed'])
+    .optional()
+    .default('processed'),
+  limit: z.coerce.number().int().min(1).max(60).optional().default(24),
+  cursor: z.string().uuid().optional(),
+});
+
+export async function GET(req: Request) {
+  try {
+    const url = new URL(req.url);
+    const parsed = QuerySchema.safeParse(Object.fromEntries(url.searchParams.entries()));
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          code: 'BAD_REQUEST',
+          message: 'Invalid query',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const { status, limit, cursor } = parsed.data;
+
+    const items = await prisma.image.findMany({
+      where: { status },
+      orderBy: [
+        { createdAt: 'desc' },
+        { id: 'desc' },
+      ],
+      take: limit + 1,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+      select: {
+        id: true,
+        url: true,
+        createdAt: true,
+        status: true,
+      },
+    });
+
+    let nextCursor: string | undefined;
+    if (items.length > limit) {
+      const next = items.pop();
+      nextCursor = next?.id;
+    }
+
+    return NextResponse.json({ items, nextCursor });
+  } catch (error) {
+    console.error('[photos] error', error);
+    return NextResponse.json(
+      { code: 'INTERNAL', message: 'Failed to list photos' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/gallery/page.tsx
+++ b/apps/web/app/gallery/page.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import * as React from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+type Photo = { id: string; url: string; createdAt: string; status: string };
+type Page = { items: Photo[]; nextCursor?: string };
+
+type FetchPageArgs = {
+  cursor?: string;
+  signal?: AbortSignal;
+};
+
+async function fetchPage({ cursor, signal }: FetchPageArgs): Promise<Page> {
+  const qs = new URLSearchParams();
+  if (cursor) {
+    qs.set('cursor', cursor);
+  }
+  const queryString = qs.toString();
+  const url = queryString ? `/api/photos?${queryString}` : '/api/photos';
+  const res = await fetch(url, { cache: 'no-store', signal });
+  if (!res.ok) {
+    throw new Error('Failed to load photos');
+  }
+  return res.json();
+}
+
+export default function GalleryPage() {
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: ['photos'],
+    queryFn: ({ pageParam, signal }) =>
+      fetchPage({ cursor: pageParam as string | undefined, signal }),
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    initialPageParam: undefined,
+  });
+
+  const sentinelRef = React.useRef<HTMLDivElement | null>(null);
+
+  React.useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const first = entries[0];
+        if (first?.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: '200px' }
+    );
+
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const photos = data?.pages.flatMap((page) => page.items) ?? [];
+
+  return (
+    <main style={{ maxWidth: 1140, margin: '0 auto', padding: 16 }}>
+      <h1 style={{ fontSize: 24, fontWeight: 600 }}>All Photos</h1>
+
+      {isLoading && <SkeletonGrid count={12} />}
+
+      {isError && (
+        <p style={{ color: 'red' }}>{error instanceof Error ? error.message : 'Error'}</p>
+      )}
+
+      {!isLoading && photos.length === 0 && (
+        <p style={{ marginTop: 12, color: '#666' }}>Chưa có ảnh đã xử lý.</p>
+      )}
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+          gap: 8,
+          marginTop: 16,
+        }}
+      >
+        {photos.map((photo) => (
+          <figure
+            key={photo.id}
+            style={{ margin: 0, position: 'relative', overflow: 'hidden', borderRadius: 8 }}
+          >
+            <img
+              src={photo.url}
+              alt="Photo"
+              style={{
+                width: '100%',
+                height: 160,
+                objectFit: 'cover',
+                display: 'block',
+                background: '#f2f2f2',
+              }}
+              loading="lazy"
+            />
+            <figcaption style={{ fontSize: 12, color: '#666', marginTop: 4 }}>
+              {new Date(photo.createdAt).toLocaleString()}
+            </figcaption>
+          </figure>
+        ))}
+      </div>
+
+      <div ref={sentinelRef} style={{ height: 1 }} />
+
+      {isFetchingNextPage && <SkeletonGrid count={6} />}
+
+      {!hasNextPage && photos.length > 0 && (
+        <div style={{ textAlign: 'center', color: '#666', fontSize: 12, marginTop: 12 }}>— hết —</div>
+      )}
+    </main>
+  );
+}
+
+function SkeletonGrid({ count }: { count: number }) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
+        gap: 8,
+        marginTop: 16,
+      }}
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <div key={index} style={{ height: 160, background: '#eee', borderRadius: 8 }} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+
+import QueryProvider from '@/components/QueryProvider';
+
+export const metadata: Metadata = {
+  title: 'Photo Organizer',
+  description: 'Organize and explore your photos.',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <QueryProvider>{children}</QueryProvider>
+      </body>
+    </html>
+  );
+}

--- a/apps/web/components/QueryProvider.tsx
+++ b/apps/web/components/QueryProvider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+
+export default function QueryProvider({ children }: { children: ReactNode }) {
+  const [client] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}

--- a/apps/web/components/Uploader.tsx
+++ b/apps/web/components/Uploader.tsx
@@ -229,6 +229,14 @@ export default function Uploader() {
             </div>
             <div style={{ fontSize: 12, marginTop: 4 }}>
               {jobStatus ? `${jobStatus.progress}% — ${jobStatus.status}` : 'Starting…'}
+              {jobStatus?.status === 'completed' && (
+                <a
+                  href="/gallery"
+                  style={{ marginLeft: 8, fontSize: 14, textDecoration: 'underline' }}
+                >
+                  View Gallery →
+                </a>
+              )}
             </div>
           </div>
         </div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.556.0",
     "@aws-sdk/s3-request-presigner": "^3.556.0",
+    "@tanstack/react-query": "^5.35.4",
     "ioredis": "^5.4.1",
     "next": "14.2.3",
     "nanoid": "^5.0.7",


### PR DESCRIPTION
## Summary
- add /api/photos endpoint with cursor-based pagination and query validation
- introduce React Query provider and /gallery page with infinite photo grid
- surface gallery link after completed upload job

## Testing
- pnpm -C apps/web lint *(fails: registry blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dea173e9788332b78329319cf60796